### PR TITLE
Enable Pipe Input

### DIFF
--- a/msm.sh
+++ b/msm.sh
@@ -148,7 +148,7 @@ if [ -p /dev/stdin ]; then
 	setup	
 
 	while IFS= read -r line; do
-		send_msg "$line"
+		send_msg "$USER: $line"
 	done
 else
 	# If continued to this point, start chat in current room & MSM directory

--- a/msm.sh
+++ b/msm.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 
 # --- GLOBAL VARS ---
 # name of room, appended to MSMDIR
@@ -136,5 +136,12 @@ while getopts r:w:d:vhc o; do
 	esac
 done
 
-# If continued to this point, start chat in current room & MSM directory
-start_chat
+# If pipe exists on stdin, write data to chat file.
+if [ -p /dev/stdin ]; then
+	while IFS= read -r line; do
+		send_msg "$line"
+	done
+else
+	# If continued to this point, start chat in current room & MSM directory
+	start_chat
+fi

--- a/msm.sh
+++ b/msm.sh
@@ -36,8 +36,8 @@ send_msg () {
 	echo -e "\r[$(date +'%H:%M')] $1" >> $MSMDIR$ROOM
 }
 
-# Opens chat & starts sending/recieving.
-start_chat () {
+# Load config and create room if needed.
+setup () {
 	load_config
 
 	# check if room directory exists. create if not
@@ -48,6 +48,12 @@ start_chat () {
 		# give write perms
 		#chmod a+rw $MSMDIR$ROOM
 	fi
+}
+
+# Opens chat & starts sending/recieving.
+start_chat () {
+	# Run setup function
+	setup
 
 	# open reading stream
 	tail -f $MSMDIR$ROOM &
@@ -138,6 +144,9 @@ done
 
 # If pipe exists on stdin, write data to chat file.
 if [ -p /dev/stdin ]; then
+	# Run setup function
+	setup	
+
 	while IFS= read -r line; do
 		send_msg "$line"
 	done


### PR DESCRIPTION
Enable pipe input, for instance

```console
cat hello.txt | msm
```

Messages will be sent like normal with the `$USER` prefix. Piping input into `msm` will not start the interactive chat.